### PR TITLE
Remove the DevRel Handbook

### DIFF
--- a/components/Resources.js
+++ b/components/Resources.js
@@ -7,10 +7,6 @@ const resourceCategories = [
         url: "https://www.amazon.com/Business-Value-Developer-Relations-Communities/dp/1484237471/ref=pd_sbs_1/137-5281060-5988909?pd_rd_w=j1ksT&pf_rd_p=f8e24c42-8be0-4374-84aa-bb08fd897453&pf_rd_r=5J80EP23D4HT23HFJA2K&pd_rd_r=fe52f5c1-5dcc-4f78-914f-126eac837a09&pd_rd_wg=jAKKa&pd_rd_i=1484237471&psc=1",
       },
       {
-        name: "The DevRel Handbook",
-        url: "https://www.devrelhandbook.com/",
-      },
-      {
         name: "Getting Started in Developer Relations",
         url: "https://learn.samjulien.com/getting-started-in-developer-relations",
       },


### PR DESCRIPTION
Hey there! Thanks for compiling this great resource.

I was clicking around and noticed the DevRel handbook. I was excited to take a look, but it doesn't actually look like the handbook every materialized. Most of the pages have no content, and the repo hasn't been touched in over two years.

- https://www.devrelhandbook.com/
- https://github.com/sethjuarez/devrelhandbook

This PR removes it from the books section of the site.